### PR TITLE
Fix injecting versioned secrets from vault-env-from-path annotation, add more tests

### DIFF
--- a/injector/injector.go
+++ b/injector/injector.go
@@ -350,8 +350,8 @@ func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretI
 
 		version := "-1"
 
-		if len(split) > 2 {
-			version = split[2]
+		if len(split) == 2 {
+			version = split[1]
 		}
 
 		data, err := i.readVaultPath(valuePath, version, false)

--- a/injector/injector_test.go
+++ b/injector/injector_test.go
@@ -64,7 +64,10 @@ func TestSecretInjector(t *testing.T) {
 
 	ciphertext := secret.Data["ciphertext"].(string) //nolint:forcetypeassert
 
-	_, err = client.RawClient().Logical().Write("secret/data/account", vault.NewData(0, map[string]interface{}{"username": "superusername", "password": "secret"}))
+	_, err = client.RawClient().Logical().Write("secret/data/account", vault.NewData(0, map[string]interface{}{"username": "superusername1", "password": "secret1"}))
+	assert.NoError(t, err)
+
+	_, err = client.RawClient().Logical().Write("secret/data/account", vault.NewData(1, map[string]interface{}{"username": "superusername", "password": "secret"}))
 	assert.NoError(t, err)
 
 	err = client.RawClient().Sys().Mount("pki", &vaultapi.MountInput{Type: "pki"})
@@ -87,6 +90,7 @@ func TestSecretInjector(t *testing.T) {
 		t.Parallel()
 
 		references := map[string]string{
+			"ACCOUNT_PASSWORD_1":              "vault:secret/data/account#password#1",
 			"ACCOUNT_PASSWORD":                "vault:secret/data/account#password",
 			"TRANSIT_SECRET":                  `>>vault:transit/decrypt/mykey#${.plaintext | b64dec}#{"ciphertext":"` + ciphertext + `"}`,
 			"ROOT_CERT":                       ">>vault:pki/root/generate/internal#certificate",
@@ -118,6 +122,7 @@ func TestSecretInjector(t *testing.T) {
 		delete(results, "INLINE_DYNAMIC_SECRET")
 
 		assert.Equal(t, map[string]string{
+			"ACCOUNT_PASSWORD_1":              "secret1",
 			"ACCOUNT_PASSWORD":                "secret",
 			"TRANSIT_SECRET":                  "secret",
 			"INLINE_SECRET":                   "scheme://superusername:secret@127.0.0.1:8080",
@@ -177,7 +182,10 @@ func TestSecretInjectorFromPath(t *testing.T) {
 	client, err := vault.NewClientFromConfig(config)
 	assert.NoError(t, err)
 
-	_, err = client.RawClient().Logical().Write("secret/data/account1", vault.NewData(0, map[string]interface{}{"password": "secret", "password2": "secret2"}))
+	_, err = client.RawClient().Logical().Write("secret/data/account1", vault.NewData(0, map[string]interface{}{"password": "secret", "password2": "secret1"}))
+	assert.NoError(t, err)
+
+	_, err = client.RawClient().Logical().Write("secret/data/account1", vault.NewData(1, map[string]interface{}{"password": "secret", "password2": "secret2"}))
 	assert.NoError(t, err)
 
 	_, err = client.RawClient().Logical().Write("secret/data/account2", vault.NewData(0, map[string]interface{}{"password3": "secret", "password4": "secret2"}))
@@ -213,6 +221,27 @@ func TestSecretInjectorFromPath(t *testing.T) {
 		}, results)
 	})
 
+	t.Run("success specific version", func(t *testing.T) {
+		t.Parallel()
+
+		paths := "secret/data/account1#1"
+
+		results := map[string]string{}
+
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
+
+		err := injector.InjectSecretsFromVaultPath(paths, injectFunc)
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]string{
+			"password":  "secret",
+			"password2": "secret1",
+		}, results)
+	})
+
 	t.Run("success multiple paths", func(t *testing.T) {
 		t.Parallel()
 
@@ -230,6 +259,28 @@ func TestSecretInjectorFromPath(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"password":  "secret",
 			"password2": "secret2",
+			"password3": "secret",
+			"password4": "secret2",
+		}, results)
+	})
+
+	t.Run("success multiple paths, specific version", func(t *testing.T) {
+		t.Parallel()
+
+		paths := "secret/data/account1#1,secret/data/account2"
+		results := map[string]string{}
+
+		injectFunc := func(key, value string) {
+			assertKeyDoesNotExist(t, results, key)
+			results[key] = value
+		}
+
+		err := injector.InjectSecretsFromVaultPath(paths, injectFunc)
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]string{
+			"password":  "secret",
+			"password2": "secret1",
 			"password3": "secret",
 			"password4": "secret2",
 		}, results)


### PR DESCRIPTION
<!--
Thank you for sending a pull request! Here are some tips for contributors:

1. Fill the description template below.
2. Include appropriate tests (if necessary). Make sure that all CI checks passed.
3. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.
-->

## Overview

<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes #7 

Fix for versioned secret paths provided in `vault.security.banzaicloud.io/vault-env-from-path` annotation, also added test cases to cover versioned Vault secrets.
