### PR TITLE
chore: change vault-env references to secret-init + add `OpenBao` injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Bank-Vaults internal libraries
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/bank-vaults/internal/ci.yaml?branch=main&style=flat-square)](https://github.com/bank-vaults/internal/actions/workflows/ci.yaml?query=workflow%3ACI)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bank-vaults/vault-env/badge?style=flat-square)](https://api.securityscorecards.dev/projects/github.com/bank-vaults/internal)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bank-vaults/secret-init/badge?style=flat-square)](https://api.securityscorecards.dev/projects/github.com/bank-vaults/internal)
 
 **Internal libraries used by Bank-Vaults components.**
 

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -23,15 +23,12 @@ import (
 	"sync"
 
 	"emperror.dev/errors"
+	"github.com/bank-vaults/secrets-webhook/pkg/common"
 	"github.com/bank-vaults/vault-sdk/vault"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/spf13/cast"
 
 	"github.com/bank-vaults/internal/configuration"
-)
-
-const (
-	MissingSecretsAnnotation = "vault.security.banzaicloud.io/vault-ignore-missing-secrets"
 )
 
 type SecretInjectorFunc func(key, value string)
@@ -305,7 +302,7 @@ func (i *SecretInjector) InjectSecretsFromVault(references map[string]string, in
 			i.logger.Warn(
 				fmt.Sprintf(
 					"path not found - We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s).",
-					MissingSecretsAnnotation,
+					common.VaultIgnoreMissingSecretsAnnotation,
 				),
 				slog.String("path", valuePath),
 			)
@@ -367,7 +364,7 @@ func (i *SecretInjector) InjectSecretsFromVaultPath(paths string, inject SecretI
 			i.logger.Warn(
 				fmt.Sprintf(
 					"path not found - We couldn't find a secret path. This is not an error since missing secrets can be ignored according to the configuration you've set (annotation: %s).",
-					MissingSecretsAnnotation,
+					common.VaultIgnoreMissingSecretsAnnotation,
 				),
 				slog.String("path", valuePath),
 			)


### PR DESCRIPTION
## Overview

- This PR changes `Vault-env` references to secret-init references.
- One `secrets-webhook` dependency needs to be added after `secrets-webhook` is added to the BV stack. 

### ⚠️ WARNING: Only merge this after the secrets webhook has been created and the dependency has been added.